### PR TITLE
Create autoresponder for pausing community contributions

### DIFF
--- a/.github/workflows/pause-community-contributions.yml
+++ b/.github/workflows/pause-community-contributions.yml
@@ -9,48 +9,13 @@ on:
       - opened
   workflow_dispatch:
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   pause:
-    name: Pause Community Contributions
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Detect if user is org member
-        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
-        id: is-organization-member
-        with:
-          script: |
-            if (context.actor == 'dependabot' || context.actor == 'exercism-bot' || context.actor == 'github-actions[bot]') {
-              return true;
-            }
-
-            return github.rest.orgs.checkMembershipForUser({
-              org: context.repo.owner,
-              username: context.actor,
-            }).then(response => response.status == 204)
-              .catch(err => true);
-      - name: Comment
-        if: steps.is-organization-member.outputs.result == 'false'
-        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
-        with:
-          script: |
-            const isIssue = !!context.payload.issue;
-            const subject = context.payload.issue || context.payload.pull_request;
-            const thing = (isIssue ? 'issue' : 'PR');
-            const aThing = (isIssue ? 'an issue' : 'a PR');
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `Hello. Thanks for opening ${aThing} on Exercism. We are currently in a phase of our journey where we have paused community contributions to allow us to take a breather and redesign our community model. You can learn more in [this blog post](https://exercism.org/blog/freeing-our-maintainers). **As such, all issues and PRs in this repository are being automatically closed.**\n\nThat doesn’t mean we’re not interested in your ideas, or that if you’re stuck on something we don’t want to help. The best place to discuss things is with our community on the Exercism Community Forum. You can use [this link](https://forum.exercism.org/new-topic?title=${encodeURI(subject.title)}&body=${encodeURI(subject.body)}&category=wasm) to copy this into a new topic there.\n\n---\n\n_Note: If this ${thing} has been pre-approved, please link back to this ${thing} on the forum thread and a maintainer or staff member will reopen it._\n`
-            })
-      - name: Close
-        if: steps.is-organization-member.outputs.result == 'false'
-        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
-        with:
-          script: |
-            github.rest.issues.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              state: 'closed',
-            })
+    if: github.repository_owner == 'exercism' # Stops this job from running on forks
+    uses: exercism/github-actions/.github/workflows/community-contributions.yml@main
+    with:
+      forum_category: wasm

--- a/.github/workflows/pause-community-contributions.yml
+++ b/.github/workflows/pause-community-contributions.yml
@@ -1,0 +1,56 @@
+name: Pause Community Contributions
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request_target:
+    types:
+      - opened
+  workflow_dispatch:
+
+jobs:
+  pause:
+    name: Pause Community Contributions
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Detect if user is org member
+        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
+        id: is-organization-member
+        with:
+          script: |
+            if (context.actor == 'dependabot' || context.actor == 'exercism-bot' || context.actor == 'github-actions[bot]') {
+              return true;
+            }
+
+            return github.rest.orgs.checkMembershipForUser({
+              org: context.repo.owner,
+              username: context.actor,
+            }).then(response => response.status == 204)
+              .catch(err => true);
+      - name: Comment
+        if: steps.is-organization-member.outputs.result == 'false'
+        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
+        with:
+          script: |
+            const isIssue = !!context.payload.issue;
+            const subject = context.payload.issue || context.payload.pull_request;
+            const thing = (isIssue ? 'issue' : 'PR');
+            const aThing = (isIssue ? 'an issue' : 'a PR');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Hello. Thanks for opening ${aThing} on Exercism. We are currently in a phase of our journey where we have paused community contributions to allow us to take a breather and redesign our community model. You can learn more in [this blog post](https://exercism.org/blog/freeing-our-maintainers). **As such, all issues and PRs in this repository are being automatically closed.**\n\nThat doesn’t mean we’re not interested in your ideas, or that if you’re stuck on something we don’t want to help. The best place to discuss things is with our community on the Exercism Community Forum. You can use [this link](https://forum.exercism.org/new-topic?title=${encodeURI(subject.title)}&body=${encodeURI(subject.body)}&category=wasm) to copy this into a new topic there.\n\n---\n\n_Note: If this ${thing} has been pre-approved, please link back to this ${thing} on the forum thread and a maintainer or staff member will reopen it._\n`
+            })
+      - name: Close
+        if: steps.is-organization-member.outputs.result == 'false'
+        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
+        with:
+          script: |
+            github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              state: 'closed',
+            })


### PR DESCRIPTION
We're going to take a step back and redesign the volunteering model for Exercism.
Please see [this forum post](https://forum.exercism.org/t/freeing-our-maintainers-exercism-wide-changes-to-track-repositories/1109) for context.

This PR adds an autoresponder that runs when an issue or PR is opened. If the person opening the issue is not a member of the Exercism organization, the autoresponder posts a comment and closes the issue. In the comment the author is directed to discuss the issue in the forum.

If the discussion in the forum results in the issue/PR being approved, a maintainer or staff member will reopen it.

Please feel free to merge this PR. It will be merged on December 1st, 2022. Please do not close it.

If you wish to discuss this, please do so in [the forum post](https://forum.exercism.org/t/freeing-our-maintainers-exercism-wide-changes-to-track-repositories/1109) rather than here.
